### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,5 +1,8 @@
 name: TODO List CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Mateus-Redivo/To-Do-List/security/code-scanning/2](https://github.com/Mateus-Redivo/To-Do-List/security/code-scanning/2)

In general, to fix this issue you should explicitly declare a `permissions` block either at the workflow root (applies to all jobs) or within each job (applies only to that job), granting only the scopes needed. For this workflow, the steps only need to read the repository contents (for `actions/checkout`) and do not push commits, modify issues/PRs, or interact with other GitHub resources, so `contents: read` is sufficient.

The best minimal fix without changing functionality is to add a workflow-level `permissions` block right after the `name:` (or after the `on:` block) in `.github/workflows/docker-image.yml`, setting `contents: read`. This will apply to the `docker-compose-up-and-test` job and any future jobs that don’t override permissions. No other code changes or imports are required, because this is purely a GitHub Actions configuration change.

Concretely:
- Edit `.github/workflows/docker-image.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the existing `name: TODO List CI` and the `on:` section (or just after `on:`; either is valid, but placing it near the top improves clarity).
- Do not alter any existing steps or job definitions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
